### PR TITLE
fix: respect user-selected iteration in Shift+I toggle

### DIFF
--- a/src/stores/backendDataStore.ts
+++ b/src/stores/backendDataStore.ts
@@ -309,9 +309,11 @@ export const backendDataStore = createStore<BackendDataStoreState>(
             currentBackend.getAssignees(),
             currentBackend.getLabels(),
           ]);
-        const autoDetected = findCurrentIteration(iterations);
+        const persisted = await currentBackend.getCurrentIteration();
         const iter =
-          autoDetected ?? (await currentBackend.getCurrentIteration());
+          persisted && persisted !== 'default'
+            ? persisted
+            : (findCurrentIteration(iterations) ?? persisted);
         const items = await currentBackend.listWorkItems(iter);
 
         set({


### PR DESCRIPTION
The refresh() method was always auto-detecting the current iteration
from date ranges, ignoring the value explicitly set by the user via
the iteration picker (Shift+I). Now the persisted getCurrentIteration()
value takes priority, with auto-detection only used as a fallback when
no explicit selection has been made (i.e., the value is still 'default').

https://claude.ai/code/session_013T4ZjnUAWAfXzu8PUrC4kA