### PR TITLE
fix: ensure label pills stay legible on the selected row

### DIFF
--- a/src/components/ColorPill.test.tsx
+++ b/src/components/ColorPill.test.tsx
@@ -22,4 +22,11 @@ describe('ColorPill', () => {
     );
     expect(lastFrame()).toContain('unknown-xyz');
   });
+
+  it('renders the value when placed on a selection background', () => {
+    const { lastFrame } = render(
+      <ColorPill field="status" value="design" selectionBg="cyanBright" />,
+    );
+    expect(lastFrame()).toContain('design');
+  });
 });

--- a/src/components/ColorPill.tsx
+++ b/src/components/ColorPill.tsx
@@ -1,17 +1,26 @@
 import { Text } from 'ink';
-import { useThemeStore } from '../stores/themeStore.js';
+import { useThemeStore, ensureContrast } from '../stores/themeStore.js';
 import type { FieldType } from '../stores/themeStore.js';
 
 export function ColorPill({
   field,
   value,
+  selectionBg,
 }: {
   field: FieldType;
   value: string;
+  /**
+   * When set, the pill is rendered on top of a selected row with this
+   * background color; the text color is adjusted to keep enough contrast.
+   */
+  selectionBg?: string;
 }) {
   const resolved = useThemeStore((s) =>
     value ? s.resolveFieldColor(field, value) : null,
   );
   if (!resolved) return <Text>{value}</Text>;
-  return <Text color={resolved.bg}>{value}</Text>;
+  const color = selectionBg
+    ? ensureContrast(resolved.bg, selectionBg)
+    : resolved.bg;
+  return <Text color={color}>{value}</Text>;
 }

--- a/src/components/WorkItemList.tsx
+++ b/src/components/WorkItemList.tsx
@@ -60,6 +60,7 @@ function buildWorkItemColumns(
   capabilities: BackendCapabilities,
   collapsedIds: Set<number>,
   selectionFg: string,
+  selectionBg: string,
 ): ColumnDef<TreeItem>[] {
   const columns: ColumnDef<TreeItem>[] = [];
 
@@ -126,7 +127,11 @@ function buildWorkItemColumns(
           {capabilities.fields.dependsOn && hasUnresolvedDeps && (
             <Text dimColor={ti.isCrossType && !selected}>{'\u29D7'} </Text>
           )}
-          <ColorPill field="status" value={ti.item.status} />
+          <ColorPill
+            field="status"
+            value={ti.item.status}
+            selectionBg={selected ? selectionBg : undefined}
+          />
         </>
       );
     },
@@ -162,7 +167,8 @@ function buildWorkItemColumns(
       width: 20,
       hidePriority: 2,
       hasData: (items) => items.some(({ item }) => item.labels.length > 0),
-      render: (ti) => {
+      render: (ti, selected) => {
+        const pillBg = selected ? selectionBg : undefined;
         const maxWidth = 20;
         const rendered: string[] = [];
         let usedWidth = 0;
@@ -175,7 +181,12 @@ function buildWorkItemColumns(
               return (
                 <Box gap={1}>
                   {rendered.map((l) => (
-                    <ColorPill key={l} field="label" value={l} />
+                    <ColorPill
+                      key={l}
+                      field="label"
+                      value={l}
+                      selectionBg={pillBg}
+                    />
                   ))}
                   <Text dimColor>+{remaining}</Text>
                 </Box>
@@ -189,7 +200,7 @@ function buildWorkItemColumns(
         return (
           <Box gap={1}>
             {rendered.map((l) => (
-              <ColorPill key={l} field="label" value={l} />
+              <ColorPill key={l} field="label" value={l} selectionBg={pillBg} />
             ))}
           </Box>
         );
@@ -206,9 +217,13 @@ function buildWorkItemColumns(
       hidePriority: 1,
       sortable: true,
       hasData: (items) => items.some(({ item }) => !!item.priority),
-      render: (ti) =>
+      render: (ti, selected) =>
         ti.item.priority ? (
-          <ColorPill field="priority" value={ti.item.priority} />
+          <ColorPill
+            field="priority"
+            value={ti.item.priority}
+            selectionBg={selected ? selectionBg : undefined}
+          />
         ) : (
           <Text> </Text>
         ),
@@ -1748,6 +1763,7 @@ export function WorkItemList() {
       capabilities,
       collapsedIds,
       autoFg(selectionBg),
+      selectionBg,
     );
     cols[0]!.width = maxIdLen + 2;
     return cols;

--- a/src/stores/themeStore.test.ts
+++ b/src/stores/themeStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { themeStore, autoFg, themes } from './themeStore.js';
+import { themeStore, autoFg, ensureContrast, themes } from './themeStore.js';
 
 describe('themeStore resolveFieldColor', () => {
   beforeEach(() => {
@@ -203,6 +203,29 @@ describe('autoFg', () => {
     expect(autoFg('blue')).toBe('white');
     expect(autoFg('green')).toBe('white');
     expect(autoFg('magenta')).toBe('white');
+  });
+});
+
+describe('ensureContrast', () => {
+  it('keeps a color that already contrasts with the background', () => {
+    // blue text on the cyanBright selection background reads fine
+    expect(ensureContrast('blue', 'cyanBright')).toBe('blue');
+  });
+
+  it('replaces a low-contrast color with a legible one', () => {
+    // cyan text on cyanBright is nearly invisible -> falls back to autoFg
+    expect(ensureContrast('cyan', 'cyanBright')).toBe('black');
+    expect(ensureContrast('cyanBright', 'cyanBright')).toBe('black');
+  });
+
+  it('uses white when the background is dark', () => {
+    // magenta text on a magenta selection background clashes
+    expect(ensureContrast('magenta', 'magenta')).toBe('white');
+  });
+
+  it('leaves unknown color names untouched', () => {
+    expect(ensureContrast('#123456', 'cyanBright')).toBe('#123456');
+    expect(ensureContrast('cyan', 'not-a-color')).toBe('cyan');
   });
 });
 

--- a/src/stores/themeStore.ts
+++ b/src/stores/themeStore.ts
@@ -182,6 +182,66 @@ export function autoFg(bg: string): string {
   return lightBgs.includes(bg) ? 'black' : 'white';
 }
 
+// --- Contrast helpers ---
+
+// Approximate sRGB values for the 16 ANSI color names Ink accepts, used to
+// estimate whether two named colors have enough perceptual contrast.
+const ANSI_RGB: Record<string, [number, number, number]> = {
+  black: [0, 0, 0],
+  red: [205, 0, 0],
+  green: [0, 205, 0],
+  yellow: [205, 205, 0],
+  blue: [0, 0, 238],
+  magenta: [205, 0, 205],
+  cyan: [0, 205, 205],
+  white: [229, 229, 229],
+  gray: [127, 127, 127],
+  grey: [127, 127, 127],
+  blackBright: [127, 127, 127],
+  redBright: [255, 0, 0],
+  greenBright: [0, 255, 0],
+  yellowBright: [255, 255, 0],
+  blueBright: [92, 92, 255],
+  magentaBright: [255, 0, 255],
+  cyanBright: [0, 255, 255],
+  whiteBright: [255, 255, 255],
+  grayBright: [168, 168, 168],
+  greyBright: [168, 168, 168],
+};
+
+function relativeLuminance([r, g, b]: [number, number, number]): number {
+  const channel = (v: number) => {
+    const c = v / 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+function contrastRatio(
+  a: [number, number, number],
+  b: [number, number, number],
+): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const lighter = Math.max(la, lb);
+  const darker = Math.min(la, lb);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/**
+ * Return a foreground color that reads clearly against `bg`. If `fg` already
+ * has sufficient contrast (or either color is unknown) it is kept as-is;
+ * otherwise it falls back to `autoFg(bg)` (black or white), which is
+ * guaranteed to contrast with the background.
+ */
+export function ensureContrast(fg: string, bg: string, min = 3): string {
+  const fgRgb = ANSI_RGB[fg];
+  const bgRgb = ANSI_RGB[bg];
+  if (!fgRgb || !bgRgb) return fg;
+  if (contrastRatio(fgRgb, bgRgb) >= min) return fg;
+  return autoFg(bg);
+}
+
 // --- Store ---
 
 export interface ThemeStoreState {


### PR DESCRIPTION
## Problem

Labels (and status/priority) render as colored **foreground** text via `ColorPill`. When a row is selected, the row background becomes `selectionBg` (default `cyanBright`). A pill whose color is close to that background — e.g. a `cyan`/`cyanBright` label, or a `design` status (cyan) — became nearly invisible against the selection background.

## Fix

- Added `ensureContrast(fg, bg, min=3)` to `themeStore`. It maps the ANSI color names Ink accepts to approximate sRGB, computes the WCAG contrast ratio, and — only when the pill color clashes with the background — falls back to `autoFg(bg)` (black/white), which is guaranteed legible. Colors that already contrast are left untouched, preserving the existing color coding.
- `ColorPill` now takes an optional `selectionBg` prop. When set, the text color is run through `ensureContrast`.
- `WorkItemList` threads the selection background into the **status**, **labels**, and **priority** pills, but only when the row is selected — so pills in non-selected rows and other screens keep their original colors.

## Testing

- New unit tests for `ensureContrast` (keeps contrasting colors, replaces clashing ones with black/white, leaves unknown color names untouched).
- New `ColorPill` test rendering a pill on a selection background.
- `npm run build`, `npm test` (1397 passed), `npm run lint`, and `npm run format:check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RL1YHAFkdL6SJJWqxJjV56)_