### PR TITLE
fix: invert selected-row text when it clashes with the row background

### DIFF
--- a/docs/plans/2026-07-29-selected-row-text-contrast-design.md
+++ b/docs/plans/2026-07-29-selected-row-text-contrast-design.md
@@ -1,0 +1,100 @@
+# Selected-row text contrast
+
+## Problem
+
+When the cursor sits on a row that has a background color, values rendered by
+`ColorPill` keep their own foreground color. If that color is perceptually close
+to the row background, the text becomes unreadable.
+
+Concretely: in the `Set Status` overlay the item `todo` resolves to `gray` via
+the keyword defaults, and the selected row's background is `selectionBg`
+(`cyanBright` in the default theme). Gray on light cyan is illegible.
+
+Two independent causes:
+
+1. `OverlayPanel` renders `<ColorPill field={fieldType} value={item.value} />`
+   without the `selectionBg` prop, so `ensureContrast()` never runs. The same
+   omission exists in `MultiSelectInput` (label picker rows) and
+   `PullRequestList` (status column).
+2. `ensureContrast()` defaults to `min = 3`. Gray on `cyanBright` scores ~3.19,
+   so even with the prop wired through the color would be kept. Cyan (~3.86),
+   yellow (~3.39) and green (~4.15) sit in the same gap.
+
+A related defect: `TableLayout` computes the row background from both `selected`
+and `marked`, but that value never leaves the row component. Columns therefore
+assume the background is always `selectionBg`, which is wrong for
+marked+selected rows (`selectedMarkedBg`) and marked-only rows (`accentBg`).
+
+## Approach
+
+Keep the existing `ensureContrast()` mechanism — a value keeps its hue when it
+still reads clearly, and falls back to `autoFg(bg)` (black or white) when it
+doesn't. Raise the threshold so borderline cases actually flip, and make every
+highlighted row pass its *actual* background down to the pills.
+
+Rejected: unconditionally forcing `autoFg(selectionBg)` on selected rows. It
+guarantees legibility but discards status/label color coding exactly while the
+cursor is on the row.
+
+## Changes
+
+### 1. `src/stores/themeStore.ts`
+
+`ensureContrast(fg, bg, min = 3)` becomes `min = 4.5` (WCAG AA for normal
+text). Against the default `cyanBright` selection background this flips gray,
+cyan, yellow, green and `greenBright` to `black`, while red (~8.8), blue (~7.5)
+and magenta (~5.3) keep their hue.
+
+The change also applies to `WorkItemList`, which already threads `selectionBg`
+through — the too-lenient threshold affects it identically.
+
+### 2. `src/components/TableLayout.tsx`
+
+- Compute the row's effective background once in `GenericTableRow` as `rowBg`
+  (`selected && marked → selectedMarkedBg`, `selected → selectionBg`,
+  `marked → accentBg`, else `undefined`).
+- Use `rowBg` for `<Box backgroundColor>` (behavior unchanged) and for the `>`
+  marker: `rowBg ? autoFg(rowBg) : accent`, replacing the hardcoded
+  `autoFg(selectionBg)`.
+- Widen `ColumnDef.render` to `(item: T, selected: boolean, rowBg: string | undefined) => ReactNode`.
+  Existing columns that ignore the third argument keep compiling.
+
+### 3. `src/components/WorkItemList.tsx`
+
+`buildWorkItemColumns` drops its `selectionFg` and `selectionBg` parameters.
+Text colors become `rowBg ? autoFg(rowBg) : undefined`; `ColorPill` receives
+`selectionBg={rowBg}`. The `useMemo` call site drops the two arguments and its
+`selectionBg` dependency.
+
+### 4. `src/components/PullRequestList.tsx`
+
+The status column currently ignores `selected` entirely; it gets
+`selectionBg={rowBg}`. The other columns' `selected ? autoFg(selectionBg)`
+expressions become `rowBg ? autoFg(rowBg) : undefined`, so `buildPrColumns`
+no longer needs its `selectionBg` parameter.
+
+### 5. `src/components/OverlayPanel.tsx` and `src/components/MultiSelectInput.tsx`
+
+Neither uses `TableLayout`; both already know `isSelected` and `selectionBg`.
+Their pills get `selectionBg={isSelected ? selectionBg : undefined}`.
+
+## Out of scope
+
+- `BranchList` and `IterationPicker` — no pills, and they never mark rows, so
+  `rowBg` would always equal `selectionBg`.
+- Selected pills stay non-bold. Surrounding text goes bold on selection; pills
+  never have, and matching them is a separate visual decision.
+- The color values themselves. Only the selected-row foreground changes.
+
+## Testing
+
+- `src/stores/themeStore.test.ts` — pin the new threshold: `gray`, `yellow`,
+  `green` on `cyanBright` resolve to `black`; `blue` still stays `blue`. The
+  existing `ensureContrast` cases must continue to pass.
+- `src/components/ColorPill.test.tsx` — assert the emitted foreground changes.
+  The current tests only check that the text appears, so they pass regardless of
+  color; the new ones assert the black SGR sequence is present for a
+  low-contrast value on `cyanBright` and absent without `selectionBg`.
+- `src/components/PullRequestList.test.tsx` — the selected row's status pill
+  renders with the inverted foreground.
+- Full `npm test`, `npm run lint`, `npm run format:check`, `tsc --noEmit`.

--- a/docs/plans/2026-07-29-selected-row-text-contrast-design.md
+++ b/docs/plans/2026-07-29-selected-row-text-contrast-design.md
@@ -16,9 +16,9 @@ Two independent causes:
    without the `selectionBg` prop, so `ensureContrast()` never runs. The same
    omission exists in `MultiSelectInput` (label picker rows) and
    `PullRequestList` (status column).
-2. `ensureContrast()` defaults to `min = 3`. Gray on `cyanBright` scores ~3.19,
-   so even with the prop wired through the color would be kept. Cyan (~3.86),
-   yellow (~3.39) and green (~4.15) sit in the same gap.
+2. `ensureContrast()` defaults to `min = 3`. Gray on `cyanBright` scores 3.19,
+   so even with the prop wired through the color would be kept. `redBright`
+   (3.19), `magenta` (3.74) and `blueBright` (3.78) sit in the same gap.
 
 A related defect: `TableLayout` computes the row background from both `selected`
 and `marked`, but that value never leaves the row component. Columns therefore
@@ -41,9 +41,15 @@ cursor is on the row.
 ### 1. `src/stores/themeStore.ts`
 
 `ensureContrast(fg, bg, min = 3)` becomes `min = 4.5` (WCAG AA for normal
-text). Against the default `cyanBright` selection background this flips gray,
-cyan, yellow, green and `greenBright` to `black`, while red (~8.8), blue (~7.5)
-and magenta (~5.3) keep their hue.
+text). Against the default `cyanBright` selection background only `black`
+(16.75), `blue` (7.49) and `red` (4.66) clear the threshold; everything else
+falls back to `black`.
+
+That is aggressive, but it is what a light selection background implies: with
+`cyanBright` at a relative luminance of 0.787, no saturated mid-luminance color
+can reach 4.5. The same holds for `selectedMarkedBg` (`magenta`), where nothing
+clears 4.5 — `autoFg()` returns the best available foreground, not a guaranteed
+one.
 
 The change also applies to `WorkItemList`, which already threads `selectionBg`
 through — the too-lenient threshold affects it identically.
@@ -88,13 +94,25 @@ Their pills get `selectionBg={isSelected ? selectionBg : undefined}`.
 
 ## Testing
 
-- `src/stores/themeStore.test.ts` — pin the new threshold: `gray`, `yellow`,
-  `green` on `cyanBright` resolve to `black`; `blue` still stays `blue`. The
-  existing `ensureContrast` cases must continue to pass.
-- `src/components/ColorPill.test.tsx` — assert the emitted foreground changes.
-  The current tests only check that the text appears, so they pass regardless of
-  color; the new ones assert the black SGR sequence is present for a
-  low-contrast value on `cyanBright` and absent without `selectionBg`.
-- `src/components/PullRequestList.test.tsx` — the selected row's status pill
-  renders with the inverted foreground.
+- `src/stores/themeStore.test.ts` — pin the new threshold: the gap cases
+  (`gray`, `redBright`, `magenta`, `blueBright` on `cyanBright`) resolve to
+  `black`, `red` and `blue` keep their hue, and an explicit `min = 3` still
+  keeps `gray`. The existing `ensureContrast` cases must continue to pass.
+- `src/components/TableLayout.test.tsx` (new) — a column captures the `rowBg` it
+  is handed and the test pins all four cases: plain, selected, marked, and
+  selected+marked. The last one is the regression guard, since columns
+  previously assumed `selectionBg`.
 - Full `npm test`, `npm run lint`, `npm run format:check`, `tsc --noEmit`.
+
+Assertions on the emitted SGR sequences are *not* included.
+`ink-testing-library` renders with colors disabled unless `FORCE_COLOR` is set,
+so `lastFrame()` contains no color information — which is why the existing
+`ColorPill` tests only check that the text appears. Forcing color globally would
+change what every other component test sees, for too little gain. The color
+decision itself is covered by the `ensureContrast` unit tests, the plumbing that
+feeds it by the `TableLayout` tests, and the prop wiring by `tsc`.
+
+Verified manually under `FORCE_COLOR=3`: with the cursor on `todo` in the status
+overlay, the value now renders `\u001b[30m` (black) on the `\u001b[106m`
+selection background instead of `\u001b[90m` (gray). The label picker behaves
+the same.

--- a/src/components/MultiSelectInput.tsx
+++ b/src/components/MultiSelectInput.tsx
@@ -147,7 +147,11 @@ export function MultiSelectInput({
                 >
                   {isToggled ? '☑ ' : '☐ '}
                 </Text>
-                <ColorPill field="label" value={item} />
+                <ColorPill
+                  field="label"
+                  value={item}
+                  selectionBg={isSelected ? selectionBg : undefined}
+                />
               </Box>
             );
           })}

--- a/src/components/OverlayPanel.tsx
+++ b/src/components/OverlayPanel.tsx
@@ -256,7 +256,11 @@ export function OverlayPanel({
                 </Text>
                 <Box flexGrow={1} gap={1}>
                   {fieldType && !item.value.startsWith('__') ? (
-                    <ColorPill field={fieldType} value={item.value} />
+                    <ColorPill
+                      field={fieldType}
+                      value={item.value}
+                      selectionBg={isSelected ? selectionBg : undefined}
+                    />
                   ) : (
                     <Text
                       color={isSelected ? autoFg(selectionBg) : undefined}

--- a/src/components/PullRequestList.tsx
+++ b/src/components/PullRequestList.tsx
@@ -30,7 +30,6 @@ const openInBrowser = async (url: string) => {
 function buildPrColumns(
   muted: string | undefined,
   mutedDim: boolean,
-  selectionBg: string,
 ): ColumnDef<PullRequest>[] {
   return [
     {
@@ -38,11 +37,8 @@ function buildPrColumns(
       header: '#',
       width: 8,
       required: true,
-      render: (pr, selected) => (
-        <Text
-          color={selected ? autoFg(selectionBg) : undefined}
-          bold={selected}
-        >
+      render: (pr, selected, rowBg) => (
+        <Text color={rowBg ? autoFg(rowBg) : undefined} bold={selected}>
           #{pr.number}
         </Text>
       ),
@@ -52,9 +48,9 @@ function buildPrColumns(
       header: 'Title',
       width: -1,
       required: true,
-      render: (pr, selected) => (
+      render: (pr, selected, rowBg) => (
         <Text
-          color={selected ? autoFg(selectionBg) : undefined}
+          color={rowBg ? autoFg(rowBg) : undefined}
           bold={selected}
           wrap="truncate"
         >
@@ -67,16 +63,18 @@ function buildPrColumns(
       header: 'Status',
       width: 12,
       hidePriority: 3,
-      render: (pr) => <ColorPill field="status" value={pr.status} />,
+      render: (pr, _selected, rowBg) => (
+        <ColorPill field="status" value={pr.status} selectionBg={rowBg} />
+      ),
     },
     {
       key: 'branches',
       header: 'Branches',
       width: 30,
       hidePriority: 2,
-      render: (pr, selected) => (
+      render: (pr, selected, rowBg) => (
         <Text
-          color={selected ? undefined : muted}
+          color={rowBg ? autoFg(rowBg) : muted}
           dimColor={!selected ? mutedDim : undefined}
           wrap="truncate"
         >
@@ -89,11 +87,8 @@ function buildPrColumns(
       header: 'Author',
       width: 16,
       hidePriority: 1,
-      render: (pr, selected) => (
-        <Text
-          color={selected ? autoFg(selectionBg) : undefined}
-          wrap="truncate"
-        >
+      render: (pr, _selected, rowBg) => (
+        <Text color={rowBg ? autoFg(rowBg) : undefined} wrap="truncate">
           {pr.author}
         </Text>
       ),
@@ -103,8 +98,8 @@ function buildPrColumns(
       header: 'Links',
       width: 6,
       hidePriority: 0,
-      render: (pr) => (
-        <Text>
+      render: (pr, _selected, rowBg) => (
+        <Text color={rowBg ? autoFg(rowBg) : undefined}>
           {pr.linkedItems.length > 0 ? String(pr.linkedItems.length) : ''}
         </Text>
       ),
@@ -113,9 +108,7 @@ function buildPrColumns(
 }
 
 export function PullRequestList() {
-  const { accent, muted, mutedDim, selectionBg } = useThemeStore(
-    (s) => s.colors,
-  );
+  const { accent, muted, mutedDim } = useThemeStore((s) => s.colors);
   const { navigate, navigateToHelp } = navigationStore.getState();
   const selectedPrId = useNavigationStore((s) => s.selectedPrId);
   const { pullRequests, capabilities } = useBackendDataStore(
@@ -130,8 +123,8 @@ export function PullRequestList() {
   const activeOverlay = useUIStore((s) => s.activeOverlay);
   const { openOverlay, closeOverlay } = uiStore.getState();
   const prColumns = useMemo(
-    () => buildPrColumns(muted, mutedDim, selectionBg),
-    [muted, mutedDim, selectionBg],
+    () => buildPrColumns(muted, mutedDim),
+    [muted, mutedDim],
   );
 
   // Set initial cursor from navigation

--- a/src/components/PullRequestList.tsx
+++ b/src/components/PullRequestList.tsx
@@ -78,7 +78,7 @@ function buildPrColumns(
           dimColor={!selected ? mutedDim : undefined}
           wrap="truncate"
         >
-          {pr.sourceBranch} \u2192 {pr.targetBranch}
+          {`${pr.sourceBranch} \u2192 ${pr.targetBranch}`}
         </Text>
       ),
     },

--- a/src/components/TableLayout.test.tsx
+++ b/src/components/TableLayout.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Text } from 'ink';
+import { render } from 'ink-testing-library';
+import { TableLayout } from './TableLayout.js';
+import type { ColumnDef } from './TableLayout.js';
+import { themeStore, themes } from '../stores/themeStore.js';
+
+interface Row {
+  id: string;
+}
+
+const rows: Row[] = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+
+const DEFAULT_COLORS = themes['default']!;
+
+/**
+ * Renders the table and returns the `rowBg` each row's column render callback
+ * was handed, keyed by row id.
+ */
+function capturedRowBgs(opts: {
+  cursor: number;
+  isMarked?: (row: Row) => boolean;
+}): Record<string, string | undefined> {
+  const seen: Record<string, string | undefined> = {};
+  const columns: ColumnDef<Row>[] = [
+    {
+      key: 'id',
+      header: 'ID',
+      width: -1,
+      required: true,
+      render: (row, _selected, rowBg) => {
+        seen[row.id] = rowBg;
+        return <Text>{row.id}</Text>;
+      },
+    },
+  ];
+  render(
+    <TableLayout
+      items={rows}
+      columns={columns}
+      cursor={opts.cursor}
+      terminalWidth={80}
+      getKey={(row) => row.id}
+      isMarked={opts.isMarked}
+    />,
+  );
+  return seen;
+}
+
+describe('TableLayout row background', () => {
+  beforeEach(() => {
+    themeStore.setState({
+      themeName: 'default',
+      colors: { ...DEFAULT_COLORS },
+    });
+  });
+
+  it('passes no background for a plain row', () => {
+    const seen = capturedRowBgs({ cursor: 0 });
+    expect(seen['b']).toBeUndefined();
+    expect(seen['c']).toBeUndefined();
+  });
+
+  it('passes selectionBg for the row under the cursor', () => {
+    const seen = capturedRowBgs({ cursor: 1 });
+    expect(seen['b']).toBe(DEFAULT_COLORS.selectionBg);
+  });
+
+  it('passes accentBg for a marked row that is not selected', () => {
+    const seen = capturedRowBgs({
+      cursor: 0,
+      isMarked: (row) => row.id === 'c',
+    });
+    expect(seen['c']).toBe(DEFAULT_COLORS.accentBg);
+  });
+
+  it('passes selectedMarkedBg when the cursor is on a marked row', () => {
+    const seen = capturedRowBgs({
+      cursor: 2,
+      isMarked: (row) => row.id === 'c',
+    });
+    expect(seen['c']).toBe(DEFAULT_COLORS.selectedMarkedBg);
+    // The same row must not report the plain selection background, which is
+    // what columns used to assume.
+    expect(seen['c']).not.toBe(DEFAULT_COLORS.selectionBg);
+  });
+});

--- a/src/components/TableLayout.tsx
+++ b/src/components/TableLayout.tsx
@@ -9,7 +9,12 @@ export interface ColumnDef<T> {
   header: string;
   /** Fixed width in chars. Use -1 for flex column (gets remaining space). */
   width: number;
-  render: (item: T, selected: boolean) => ReactNode;
+  /**
+   * `rowBg` is the background the row is actually painted with (selection,
+   * marked, or selected+marked), or `undefined` for a plain row. Use it to
+   * derive foreground colors instead of assuming `selectionBg`.
+   */
+  render: (item: T, selected: boolean, rowBg: string | undefined) => ReactNode;
   /** If true, column is never hidden responsively. Default false. */
   required?: boolean;
   /** Higher number = kept longer when space is tight. Default 0. */
@@ -129,21 +134,19 @@ const GenericTableRow = memo(function GenericTableRow<T>({
   const { accent, accentBg, selectionBg, selectedMarkedBg } = useThemeStore(
     (s) => s.colors,
   );
+  const rowBg =
+    selected && marked
+      ? selectedMarkedBg
+      : selected
+        ? selectionBg
+        : marked
+          ? accentBg
+          : undefined;
   return (
-    <Box
-      backgroundColor={
-        selected && marked
-          ? selectedMarkedBg
-          : selected
-            ? selectionBg
-            : marked
-              ? accentBg
-              : undefined
-      }
-    >
+    <Box backgroundColor={rowBg}>
       {showMarker && (
         <Box width={MARKER_WIDTH}>
-          <Text color={selected ? autoFg(selectionBg) : accent}>
+          <Text color={rowBg ? autoFg(rowBg) : accent}>
             {selected ? '>' : ' '}
           </Text>
         </Box>
@@ -162,7 +165,7 @@ const GenericTableRow = memo(function GenericTableRow<T>({
             marginRight={isLast ? 0 : gap}
             overflowX="hidden"
           >
-            {colDef.render(item, selected)}
+            {colDef.render(item, selected, rowBg)}
           </Box>
         );
       })}

--- a/src/components/WorkItemList.tsx
+++ b/src/components/WorkItemList.tsx
@@ -59,8 +59,6 @@ const EMPTY_VIEWS: SavedView[] = [];
 function buildWorkItemColumns(
   capabilities: BackendCapabilities,
   collapsedIds: Set<number>,
-  selectionFg: string,
-  selectionBg: string,
 ): ColumnDef<TreeItem>[] {
   const columns: ColumnDef<TreeItem>[] = [];
 
@@ -71,9 +69,9 @@ function buildWorkItemColumns(
     width: 4, // overridden dynamically via useMemo
     required: true,
     sortable: true,
-    render: (ti, selected) => (
+    render: (ti, selected, rowBg) => (
       <Text
-        color={selected ? selectionFg : undefined}
+        color={rowBg ? autoFg(rowBg) : undefined}
         bold={selected}
         dimColor={ti.isCrossType && !selected}
       >
@@ -89,7 +87,7 @@ function buildWorkItemColumns(
     width: -1,
     required: true,
     sortable: true,
-    render: (ti, selected) => {
+    render: (ti, selected, rowBg) => {
       const { item, prefix, isCrossType, hasChildren } = ti;
       const collapseIndicator = hasChildren
         ? collapsedIds.has(item.rowId)
@@ -99,7 +97,7 @@ function buildWorkItemColumns(
       const typeLabel = isCrossType ? ` (${item.type})` : '';
       return (
         <Text
-          color={selected ? selectionFg : undefined}
+          color={rowBg ? autoFg(rowBg) : undefined}
           bold={selected}
           dimColor={isCrossType && !selected}
           wrap="truncate"
@@ -120,7 +118,7 @@ function buildWorkItemColumns(
     width: 14,
     hidePriority: 3,
     sortable: true,
-    render: (ti, selected) => {
+    render: (ti, selected, rowBg) => {
       const hasUnresolvedDeps = ti.item.dependsOn.length > 0;
       return (
         <>
@@ -130,7 +128,7 @@ function buildWorkItemColumns(
           <ColorPill
             field="status"
             value={ti.item.status}
-            selectionBg={selected ? selectionBg : undefined}
+            selectionBg={rowBg}
           />
         </>
       );
@@ -146,9 +144,9 @@ function buildWorkItemColumns(
       hidePriority: 4,
       sortable: true,
       hasData: (items) => items.some(({ item }) => !!item.assignee),
-      render: (ti, selected) => (
+      render: (ti, selected, rowBg) => (
         <Text
-          color={selected ? selectionFg : undefined}
+          color={rowBg ? autoFg(rowBg) : undefined}
           bold={selected}
           dimColor={ti.isCrossType && !selected}
           wrap="truncate"
@@ -167,8 +165,7 @@ function buildWorkItemColumns(
       width: 20,
       hidePriority: 2,
       hasData: (items) => items.some(({ item }) => item.labels.length > 0),
-      render: (ti, selected) => {
-        const pillBg = selected ? selectionBg : undefined;
+      render: (ti, _selected, rowBg) => {
         const maxWidth = 20;
         const rendered: string[] = [];
         let usedWidth = 0;
@@ -185,7 +182,7 @@ function buildWorkItemColumns(
                       key={l}
                       field="label"
                       value={l}
-                      selectionBg={pillBg}
+                      selectionBg={rowBg}
                     />
                   ))}
                   <Text dimColor>+{remaining}</Text>
@@ -200,7 +197,7 @@ function buildWorkItemColumns(
         return (
           <Box gap={1}>
             {rendered.map((l) => (
-              <ColorPill key={l} field="label" value={l} selectionBg={pillBg} />
+              <ColorPill key={l} field="label" value={l} selectionBg={rowBg} />
             ))}
           </Box>
         );
@@ -217,12 +214,12 @@ function buildWorkItemColumns(
       hidePriority: 1,
       sortable: true,
       hasData: (items) => items.some(({ item }) => !!item.priority),
-      render: (ti, selected) =>
+      render: (ti, _selected, rowBg) =>
         ti.item.priority ? (
           <ColorPill
             field="priority"
             value={ti.item.priority}
-            selectionBg={selected ? selectionBg : undefined}
+            selectionBg={rowBg}
           />
         ) : (
           <Text> </Text>
@@ -305,7 +302,6 @@ export function WorkItemList() {
     warning: warningColor,
     marked,
     mutedDim,
-    selectionBg,
   } = useThemeStore((s) => s.colors);
 
   // Backend data store - split by change frequency for minimal re-renders
@@ -1759,15 +1755,10 @@ export function WorkItemList() {
       (max, { item }) => Math.max(max, (item.id ?? '\u00B7').length),
       2,
     );
-    const cols = buildWorkItemColumns(
-      capabilities,
-      collapsedIds,
-      autoFg(selectionBg),
-      selectionBg,
-    );
+    const cols = buildWorkItemColumns(capabilities, collapsedIds);
     cols[0]!.width = maxIdLen + 2;
     return cols;
-  }, [visibleTreeItems, capabilities, collapsedIds, selectionBg]);
+  }, [visibleTreeItems, capabilities, collapsedIds]);
 
   const positionText =
     treeItems.length > viewport.maxVisible

--- a/src/stores/themeStore.test.ts
+++ b/src/stores/themeStore.test.ts
@@ -223,6 +223,25 @@ describe('ensureContrast', () => {
     expect(ensureContrast('magenta', 'magenta')).toBe('white');
   });
 
+  it('inverts colors that only just clear a 3:1 ratio', () => {
+    // These score between 3 and 4.5 against cyanBright -- legible enough for
+    // the old threshold, unreadable in practice. `gray` is what the `todo`
+    // status resolves to in the status picker.
+    expect(ensureContrast('gray', 'cyanBright')).toBe('black');
+    expect(ensureContrast('redBright', 'cyanBright')).toBe('black');
+    expect(ensureContrast('magenta', 'cyanBright')).toBe('black');
+    expect(ensureContrast('blueBright', 'cyanBright')).toBe('black');
+  });
+
+  it('keeps hues that clear the AA threshold', () => {
+    expect(ensureContrast('red', 'cyanBright')).toBe('red');
+    expect(ensureContrast('blue', 'cyanBright')).toBe('blue');
+  });
+
+  it('honours an explicit min override', () => {
+    expect(ensureContrast('gray', 'cyanBright', 3)).toBe('gray');
+  });
+
   it('leaves unknown color names untouched', () => {
     expect(ensureContrast('#123456', 'cyanBright')).toBe('#123456');
     expect(ensureContrast('cyan', 'not-a-color')).toBe('cyan');

--- a/src/stores/themeStore.ts
+++ b/src/stores/themeStore.ts
@@ -233,8 +233,12 @@ function contrastRatio(
  * has sufficient contrast (or either color is unknown) it is kept as-is;
  * otherwise it falls back to `autoFg(bg)` (black or white), which is
  * guaranteed to contrast with the background.
+ *
+ * `min` defaults to the WCAG AA ratio for normal text. A looser 3:1 leaves
+ * gray, cyan, yellow and green illegible on the light `cyanBright` selection
+ * background — they all score between 3 and 4.5.
  */
-export function ensureContrast(fg: string, bg: string, min = 3): string {
+export function ensureContrast(fg: string, bg: string, min = 4.5): string {
   const fgRgb = ANSI_RGB[fg];
   const bgRgb = ANSI_RGB[bg];
   if (!fgRgb || !bgRgb) return fg;


### PR DESCRIPTION
## What changed

Text on a highlighted row now inverts to black/white whenever it would clash with that row's background colour.

Reported symptom: in the `Set Status` picker, the item `todo` was unreadable while the cursor sat on it.

### Two independent causes

1. **Missing prop.** The `ensureContrast` mechanism added in 93fe437 was only ever wired into `WorkItemList`. `OverlayPanel` (every property picker — `s`/`t`/`l`/`i`/`x`), `MultiSelectInput` (the form's label picker) and `PullRequestList` (status column) rendered `ColorPill` without `selectionBg`, so the contrast check never ran on those rows.
2. **Threshold too lenient.** `ensureContrast` defaulted to a 3:1 ratio. `gray` — what `todo` resolves to via the keyword defaults — scores **3.19** against the `cyanBright` selection background, so it passed the check and stayed gray. The default is now 4.5:1 (WCAG AA for normal text).

### Related defect fixed along the way

`TableLayout` computed each row's background from *both* `selected` and `marked`, but never exposed it — so column renderers hardcoded `selectionBg` and used the wrong reference colour on marked rows. `ColumnDef.render` is now `(item, selected, rowBg)`, where `rowBg` is the background the row is actually painted with. This also makes marked-only rows (`accentBg`) legible for free, and let `buildWorkItemColumns` and `buildPrColumns` drop their `selectionFg`/`selectionBg` parameters entirely.

The third commit fixes an unrelated pre-existing bug spotted in a touched file: the PR list's branches column had `→` sitting in JSX *text* content, where backslash escapes are not interpreted, so it displayed the literal string `→` instead of an arrow.

## Reviewer notes

**On `cyanBright`, only `black` (16.75), `blue` (7.49) and `red` (4.66) can clear 4.5 — so in practice most pills go black while the cursor is on them.** That is inherent to a light selection background, not a stylistic choice: at a relative luminance of 0.787, no saturated mid-luminance colour can reach AA against it. The same holds for `selectedMarkedBg` (`magenta`), where nothing clears 4.5 — `autoFg()` returns the best available foreground, not a guaranteed one. If you'd prefer more hue retained on the selected row, the lever is a darker `selectionBg`, not the threshold.

Raising the default also affects `WorkItemList`, which already threaded `selectionBg` through. That is intended — the too-lenient threshold affected it identically.

Deliberately out of scope: selected pills stay non-bold (surrounding text goes bold on selection, pills never have — matching them is a separate visual decision), and no colour *values* changed.

## Verification

`npm run build`, `npm test` (1404 passed / 98 files), `npm run lint`, `npm run format:check` — all clean.

New tests: `TableLayout.test.tsx` pins all four `rowBg` cases (plain, selected, marked, selected+marked — the last being the regression guard), and `themeStore.test.ts` pins the new threshold's gap cases.

Assertions on emitted SGR sequences are **not** included: `ink-testing-library` renders with colours disabled unless `FORCE_COLOR` is set, so `lastFrame()` carries no colour information — which is why the pre-existing `ColorPill` tests only check that text appears. Forcing colour globally would change what every other component test sees, for too little gain. Instead the colour decision is covered by the `ensureContrast` unit tests, the plumbing by the `TableLayout` tests, and the prop wiring by `tsc`.

Both visual outcomes were verified by hand against real rendered output rather than by reasoning:

- Under `FORCE_COLOR=3`, with the cursor on `todo`, the value renders `ESC[30m` (black) on the `ESC[106m` selection background instead of `ESC[90m` (gray). The label picker behaves the same.
- The arrow fix was confirmed with hexdumped bytes to guarantee a genuine backslash: JSX text child renders a literal `→`; template literal renders a real arrow.

Design notes: `docs/plans/2026-07-29-selected-row-text-contrast-design.md`.
