### PR TITLE
fix: collect and display Azure DevOps comments in detail panel

### DIFF
--- a/src/backends/ado/ado.test.ts
+++ b/src/backends/ado/ado.test.ts
@@ -253,6 +253,8 @@ describe('AzureDevOpsBackend', () => {
           },
         ],
       });
+      // Comments fetch per item
+      mockApi.rest.mockResolvedValue({ comments: [] });
 
       const items = await backend.listWorkItems();
       expect(items).toHaveLength(2);
@@ -270,6 +272,7 @@ describe('AzureDevOpsBackend', () => {
       mockApi.batchGetWorkItems.mockResolvedValueOnce({
         value: [sampleWorkItem],
       });
+      mockApi.rest.mockResolvedValue({ comments: [] });
 
       await backend.listWorkItems('WebApp\\Sprint 1');
 

--- a/src/backends/ado/index.ts
+++ b/src/backends/ado/index.ts
@@ -227,6 +227,16 @@ export class AzureDevOpsBackend
     return result.value.map(mapWorkItemToWorkItem);
   }
 
+  private async fetchComments(id: number | string): Promise<Comment[]> {
+    const commentResult = await this.api
+      .rest<{ comments: AdoComment[] }>(
+        'GET',
+        `/${encodeURIComponent(this.project)}/_apis/wit/workItems/${id}/comments?api-version=7.1-preview.4`,
+      )
+      .catch(() => ({ comments: [] as AdoComment[] }));
+    return (commentResult.comments ?? []).map(mapCommentToComment);
+  }
+
   async listWorkItems(iteration?: string): Promise<WorkItem[]> {
     let wiql = `SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = '${this.escapeWiql(this.project)}'`;
     if (iteration) {
@@ -241,28 +251,27 @@ export class AzureDevOpsBackend
     if (ids.length === 0) return [];
 
     const items = await this.batchFetchWorkItems(ids);
+    const comments = await Promise.all(
+      items.map((item) => this.fetchComments(item.rowId)),
+    );
+    items.forEach((item, i) => {
+      item.comments = comments[i]!;
+    });
     items.sort((a, b) => b.updated.localeCompare(a.updated));
     return items;
   }
 
   async getWorkItem(id: string): Promise<WorkItem> {
-    const [ado, commentResult] = await Promise.all([
+    const [ado, comments] = await Promise.all([
       this.api.rest<AdoWorkItem>(
         'GET',
         `/${encodeURIComponent(this.project)}/_apis/wit/workitems/${id}?$expand=relations`,
       ),
-      this.api
-        .rest<{
-          comments: AdoComment[];
-        }>(
-          'GET',
-          `/${encodeURIComponent(this.project)}/_apis/wit/workItems/${id}/comments?api-version=7.1-preview.4`,
-        )
-        .catch(() => ({ comments: [] as AdoComment[] })),
+      this.fetchComments(id),
     ]);
 
     const item = mapWorkItemToWorkItem(ado);
-    item.comments = (commentResult.comments ?? []).map(mapCommentToComment);
+    item.comments = comments;
     return item;
   }
 

--- a/src/components/DetailPanel.tsx
+++ b/src/components/DetailPanel.tsx
@@ -177,6 +177,19 @@ export function DetailPanel({
           ))}
         </Box>
       )}
+      {showFullDescription && item.comments.length > 0 && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text bold>Comments</Text>
+          {item.comments.map((comment, idx) => (
+            <Box key={idx} flexDirection="column" marginTop={idx > 0 ? 1 : 0}>
+              <Text dimColor={mutedDim}>
+                {comment.author} · {comment.date}
+              </Text>
+              <Text wrap="wrap">{comment.body}</Text>
+            </Box>
+          ))}
+        </Box>
+      )}
     </Box>
   );
 }

--- a/src/storage/index.test.ts
+++ b/src/storage/index.test.ts
@@ -1466,11 +1466,11 @@ describe('Storage', () => {
   // ─── comment loading optimization ──────────────────────────────
 
   describe('comment loading', () => {
-    it('listWorkItems omits comments by default', async () => {
+    it('listWorkItems includes comments', async () => {
       const item = await backend.createWorkItem(makeNewWorkItem());
       await backend.addComment(item.id!, { body: 'hello', author: 'me' });
       const items = await backend.listWorkItems();
-      expect(items[0]!.comments).toEqual([]);
+      expect(items[0]!.comments).toHaveLength(1);
     });
 
     it('getWorkItem includes comments', async () => {

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -341,7 +341,7 @@ export class Storage
 
     if (itemRows.length === 0) return [];
 
-    return this.assembleWorkItems(itemRows);
+    return this.assembleWorkItems(itemRows, { includeComments: true });
   }
 
   // eslint-disable-next-line @typescript-eslint/require-await


### PR DESCRIPTION
## Summary
- ADO's `listWorkItems()` (bulk sync) never fetched comments — only the single-item `getWorkItem()` did — so comments never made it into local storage during sync.
- `Storage.listWorkItems()` also stripped comments for every backend's in-memory item list.
- `DetailPanel` had no comments UI at all.

Now ADO comments are collected during sync, `Storage.listWorkItems()` includes them, and the detail panel shows a "Comments" section (only when at least one comment exists) when the full description view is expanded (spacebar).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite passes; one pre-existing unrelated flaky test confirmed via stash-comparison against main)
- [x] `npm run lint`
- [x] `npm run format:check`